### PR TITLE
Add length of trails to transportation layer

### DIFF
--- a/layers/transportation/transportation.yaml
+++ b/layers/transportation/transportation.yaml
@@ -135,10 +135,13 @@ layer:
       values:
       - paved
       - unpaved
+    trail_length:
+      description: |
+          Distance in meters of trail linestring. Only defined for class=path.
   datasource:
     geometry_field: geometry
     srid: 900913
-    query: (SELECT geometry, class, subclass, oneway, ramp, brunnel, service, layer, level, indoor, bicycle, foot, horse, mtb_scale, surface FROM layer_transportation(!bbox!, z(!scale_denominator!))) AS t
+    query: (SELECT geometry, class, subclass, oneway, ramp, brunnel, service, layer, level, indoor, bicycle, foot, horse, mtb_scale, surface, trail_length FROM layer_transportation(!bbox!, z(!scale_denominator!))) AS t
 schema:
   - ./class.sql
   - ./update_transportation_merge.sql


### PR DESCRIPTION
Adds trail length to the transportation layer. This is computationally intensive because each LineString is currently reprojected to WGS84 and then taken the length of (in meters).

For now, this is only computed at zooms >=12, and only on `class=path`. It doesn't show up on non-`class=path`, which means that it should increase the size of the vector tiles only marginally:
![image](https://user-images.githubusercontent.com/15164633/73202919-140b8880-410a-11ea-9585-47095083acbf.png)


Ideally I'll also split LineStrings at intersections, but I haven't figured that out yet.

![image](https://user-images.githubusercontent.com/15164633/73202836-e58dad80-4109-11ea-82ef-0ce6b30ff1cf.png)
![image](https://user-images.githubusercontent.com/15164633/73202843-e9213480-4109-11ea-97f2-a607e5579732.png)
